### PR TITLE
feat: improve VentaForm UX, fix client dropdown, and refactor admin UI

### DIFF
--- a/gaming-laptop-store/src/components/admin/ClientesForm.jsx
+++ b/gaming-laptop-store/src/components/admin/ClientesForm.jsx
@@ -90,7 +90,7 @@ const ClientesForm = ({ onClose, onSubmit, cliente }) => {
       onSubmit={handleSubmit}
     >
       <div className="cf-form-grid">
-        <div className="cf-form-group">
+        <div className="form-group">
           <label htmlFor="nombre_completo">
             Nombre Completo <span className="required">*</span>
           </label>
@@ -105,7 +105,7 @@ const ClientesForm = ({ onClose, onSubmit, cliente }) => {
           />
         </div>
 
-        <div className="cf-form-group">
+        <div className="form-group">
           <label htmlFor="cedula">
             Cédula <span className="required">*</span>
           </label>
@@ -120,7 +120,7 @@ const ClientesForm = ({ onClose, onSubmit, cliente }) => {
           />
         </div>
 
-        <div className="cf-form-group">
+        <div className="form-group">
           <label htmlFor="celular">
             Celular <span className="required">*</span>
           </label>
@@ -135,7 +135,7 @@ const ClientesForm = ({ onClose, onSubmit, cliente }) => {
           />
         </div>
 
-        <div className="cf-form-group">
+        <div className="form-group">
           <label htmlFor="correo">
             Correo <span className="required">*</span>
           </label>
@@ -150,7 +150,7 @@ const ClientesForm = ({ onClose, onSubmit, cliente }) => {
           />
         </div>
 
-        <div className="cf-form-group cf-full">
+        <div className="form-group cf-full">
           <label htmlFor="direccion">
             Dirección <span className="required">*</span>
           </label>
@@ -165,7 +165,7 @@ const ClientesForm = ({ onClose, onSubmit, cliente }) => {
           />
         </div>
 
-        <div className="cf-form-group">
+        <div className="form-group">
           <label htmlFor="departamento">
             Departamento <span className="required">*</span>
           </label>
@@ -185,7 +185,7 @@ const ClientesForm = ({ onClose, onSubmit, cliente }) => {
           </select>
         </div>
 
-        <div className="cf-form-group">
+        <div className="form-group">
           <label htmlFor="ciudad">
             Ciudad <span className="required">*</span>
           </label>

--- a/gaming-laptop-store/src/components/admin/ModalBase.jsx
+++ b/gaming-laptop-store/src/components/admin/ModalBase.jsx
@@ -12,6 +12,7 @@ const ModalBase = ({
   onSubmit,
   isSubmitting = false,
   cancelLabel,
+  className,
 }) => {
   const modalRef = useRef();
 
@@ -33,7 +34,7 @@ const ModalBase = ({
 
   return (
     <div className="modal-overlay">
-      <div className="modal-container" ref={modalRef}>
+      <div className={`modal-container${className ? ` ${className}` : ''}`} ref={modalRef}>
         {/* Header */}
         <div className="modal-header">
           <div className="modal-title">

--- a/gaming-laptop-store/src/components/admin/SeparacionForm.jsx
+++ b/gaming-laptop-store/src/components/admin/SeparacionForm.jsx
@@ -27,7 +27,7 @@ const SeparacionForm = ({ onClose, onSubmit, separacion, preselectedUnidadId }) 
   const fetchData = async () => {
     try {
       const clientesData = await ClienteService.getClientes();
-      setClientes(clientesData.cliente || []);
+      setClientes(Array.isArray(clientesData) ? clientesData : (clientesData.clientes || []));
 
       const unidadesData = await UnidadService.getUnidades();
       setUnidades(unidadesData || []);

--- a/gaming-laptop-store/src/components/admin/UnidadProductoForm.jsx
+++ b/gaming-laptop-store/src/components/admin/UnidadProductoForm.jsx
@@ -3,15 +3,17 @@ import { Box, Edit } from "lucide-react";
 import ModalBase from "./ModalBase";
 import "../../styles/admin/unidadForm.css";
 
+// 'vendido' y 'separado' are auto-assigned by Venta/Separación — not manually selectable
 const ESTADO_VENTA_OPTIONS = [
   { value: "sin_vender", label: "Sin Vender" },
-  { value: "separado", label: "Separado" },
-  { value: "vendido", label: "Vendido" },
   { value: "por_encargo", label: "Por Encargo" },
   { value: "entregado_garantia", label: "Entregado en Garantía" },
   { value: "danado", label: "Dañado" },
   { value: "solicitud_metodo_aliado", label: "Solicitud Método Aliado" },
 ];
+
+const LOCKED_STATES = ["vendido", "separado"];
+const LOCKED_LABELS = { vendido: "Vendido", separado: "Separado" };
 
 const ESTADO_PRODUCTO_OPTIONS = [
   { value: "en_stock", label: "En Stock" },
@@ -62,6 +64,7 @@ const UnidadProductoForm = ({
   submitError,
 }) => {
   const isEditMode = Boolean(unidad);
+  const isLocked = isEditMode && LOCKED_STATES.includes(unidad?.estado_venta);
 
   const [formData, setFormData] = useState({ ...EMPTY_FORM, condicion: condicionDefault });
   const [errors, setErrors] = useState({});
@@ -140,10 +143,17 @@ const UnidadProductoForm = ({
           : "Completa la información para registrar una nueva unidad"
       }
       onClose={onClose}
-      onSubmit={handleSubmit}
+      onSubmit={isLocked ? undefined : handleSubmit}
       isSubmitting={isSubmitting}
     >
       {submitError && <div className="form-error-banner">{submitError}</div>}
+
+      {isLocked && (
+        <div className="uf-locked-banner">
+          Esta unidad está marcada como <strong>{LOCKED_LABELS[unidad.estado_venta]}</strong>.
+          Para editarla, primero elimine la venta o separación asociada.
+        </div>
+      )}
 
       {/* Product context banner */}
       <div className="uf-variant-banner">
@@ -165,7 +175,7 @@ const UnidadProductoForm = ({
             placeholder="Ej: SN-123456789"
             value={formData.serial}
             onChange={handleChange}
-            disabled={isSubmitting}
+            disabled={isSubmitting || isLocked}
             required
           />
           {errors.serial && <span className="uf-field-error">{errors.serial}</span>}
@@ -181,7 +191,7 @@ const UnidadProductoForm = ({
             name="condicion"
             value={formData.condicion}
             onChange={handleChange}
-            disabled={isSubmitting}
+            disabled={isSubmitting || isLocked}
             required
           >
             {CONDICION_OPTIONS.map((opt) => (
@@ -205,7 +215,7 @@ const UnidadProductoForm = ({
             placeholder="Ej: 4500000"
             value={formData.precio}
             onChange={handleChange}
-            disabled={isSubmitting}
+            disabled={isSubmitting || isLocked}
             required
           />
           {errors.precio && <span className="uf-field-error">{errors.precio}</span>}
@@ -221,12 +231,15 @@ const UnidadProductoForm = ({
             name="estado_venta"
             value={formData.estado_venta}
             onChange={handleChange}
-            disabled={isSubmitting}
+            disabled={isSubmitting || isLocked}
             required
           >
-            {ESTADO_VENTA_OPTIONS.map((opt) => (
-              <option key={opt.value} value={opt.value}>{opt.label}</option>
-            ))}
+            {isLocked
+              ? <option value={formData.estado_venta}>{LOCKED_LABELS[formData.estado_venta]}</option>
+              : ESTADO_VENTA_OPTIONS.map((opt) => (
+                  <option key={opt.value} value={opt.value}>{opt.label}</option>
+                ))
+            }
           </select>
           {errors.estado_venta && <span className="uf-field-error">{errors.estado_venta}</span>}
         </div>
@@ -241,7 +254,7 @@ const UnidadProductoForm = ({
             name="estado_producto"
             value={formData.estado_producto}
             onChange={handleChange}
-            disabled={isSubmitting}
+            disabled={isSubmitting || isLocked}
             required
           >
             {ESTADO_PRODUCTO_OPTIONS.map((opt) => (

--- a/gaming-laptop-store/src/components/admin/VentaForm.jsx
+++ b/gaming-laptop-store/src/components/admin/VentaForm.jsx
@@ -1,5 +1,5 @@
-import React, { useState, useEffect } from "react";
-import { ShoppingCart, Edit, Trash2, Plus, UserPlus, Users } from "lucide-react";
+import React, { useState, useEffect, useRef } from "react";
+import { ShoppingCart, Edit, Trash2, Plus, UserPlus, Users, Search } from "lucide-react";
 import ModalBase from "../../components/admin/ModalBase";
 import * as ClienteService from "../../services/ClienteService";
 import * as UnidadService from "../../services/UnidadService";
@@ -35,11 +35,25 @@ const VentaForm = ({ onClose, onSubmit, venta, preselectedUnidadId }) => {
   const [ciudades, setCiudades] = useState([]);
   const [selectedUnidad, setSelectedUnidad] = useState("");
   const [selectedPrecio, setSelectedPrecio] = useState("");
+  const [unidadSearch, setUnidadSearch] = useState("");
+  const [showUnidadDropdown, setShowUnidadDropdown] = useState(false);
+  const unidadSearchRef = useRef(null);
 
   const isEditMode = Boolean(venta);
 
   useEffect(() => {
     fetchData();
+  }, []);
+
+  // Close unit search dropdown on outside click
+  useEffect(() => {
+    const handleClickOutside = (e) => {
+      if (unidadSearchRef.current && !unidadSearchRef.current.contains(e.target)) {
+        setShowUnidadDropdown(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
   }, []);
 
   const fetchData = async () => {
@@ -51,7 +65,7 @@ const VentaForm = ({ onClose, onSubmit, venta, preselectedUnidadId }) => {
         api.get(urls.ciudadesList).then((r) => r.data),
       ]);
 
-      setClientes(clientesData.cliente || []);
+      setClientes(Array.isArray(clientesData) ? clientesData : (clientesData.clientes || []));
       setUnidades(unidadesData || []);
       setDepartamentos(Array.isArray(deptosData) ? deptosData : (deptosData.departamentos || []));
       setCiudades(Array.isArray(ciudadesData) ? ciudadesData : (ciudadesData.ciudades || []));
@@ -119,6 +133,28 @@ const VentaForm = ({ onClose, onSubmit, venta, preselectedUnidadId }) => {
     return Object.keys(errs).length === 0;
   };
 
+  // Unidades available: sin_vender and not already added
+  const selectedIds = formData.items_data.map((i) => i.unidad_producto);
+  const availableUnidades = unidades.filter(
+    (u) => u.estado_venta === "sin_vender" && !selectedIds.includes(u.id)
+  );
+  const filteredDropdownUnidades = unidadSearch.trim()
+    ? availableUnidades.filter((u) => {
+        const term = unidadSearch.toLowerCase();
+        return (
+          u.serial?.toLowerCase().includes(term) ||
+          u.producto_nombre?.toLowerCase().includes(term)
+        );
+      })
+    : availableUnidades;
+
+  const handleSelectUnidad = (unidad) => {
+    setSelectedUnidad(String(unidad.id));
+    setSelectedPrecio(unidad.precio);
+    setUnidadSearch(`${unidad.serial} - ${unidad.producto_nombre}`);
+    setShowUnidadDropdown(false);
+  };
+
   const handleAddItem = () => {
     if (!selectedUnidad || !selectedPrecio) {
       alert("Debe seleccionar unidad y precio");
@@ -134,6 +170,7 @@ const VentaForm = ({ onClose, onSubmit, venta, preselectedUnidadId }) => {
     setFormData((prev) => ({ ...prev, items_data: [...prev.items_data, newItem] }));
     setSelectedUnidad("");
     setSelectedPrecio("");
+    setUnidadSearch("");
   };
 
   const handleRemoveItem = (index) => {
@@ -208,6 +245,7 @@ const VentaForm = ({ onClose, onSubmit, venta, preselectedUnidadId }) => {
       }
       onClose={onClose}
       onSubmit={handleSubmit}
+      className="vf-modal-wide"
     >
       <div className="vf-form-grid">
 
@@ -252,7 +290,7 @@ const VentaForm = ({ onClose, onSubmit, venta, preselectedUnidadId }) => {
         {clienteMode === "nuevo" && (
           <div className="vf-nuevo-cliente vf-full">
             <div className="vf-nuevo-cliente-grid">
-              <div className="vf-form-group">
+              <div className="form-group">
                 <label>Nombre completo <span className="required">*</span></label>
                 <input
                   name="nombre_completo"
@@ -264,7 +302,7 @@ const VentaForm = ({ onClose, onSubmit, venta, preselectedUnidadId }) => {
                 {nuevoClienteErrors.nombre_completo && <span className="vf-field-error">{nuevoClienteErrors.nombre_completo}</span>}
               </div>
 
-              <div className="vf-form-group">
+              <div className="form-group">
                 <label>Cédula <span className="required">*</span></label>
                 <input
                   name="cedula"
@@ -276,7 +314,7 @@ const VentaForm = ({ onClose, onSubmit, venta, preselectedUnidadId }) => {
                 {nuevoClienteErrors.cedula && <span className="vf-field-error">{nuevoClienteErrors.cedula}</span>}
               </div>
 
-              <div className="vf-form-group">
+              <div className="form-group">
                 <label>Celular <span className="required">*</span></label>
                 <input
                   name="celular"
@@ -288,7 +326,7 @@ const VentaForm = ({ onClose, onSubmit, venta, preselectedUnidadId }) => {
                 {nuevoClienteErrors.celular && <span className="vf-field-error">{nuevoClienteErrors.celular}</span>}
               </div>
 
-              <div className="vf-form-group">
+              <div className="form-group">
                 <label>Correo <span className="required">*</span></label>
                 <input
                   name="correo"
@@ -300,7 +338,7 @@ const VentaForm = ({ onClose, onSubmit, venta, preselectedUnidadId }) => {
                 {nuevoClienteErrors.correo && <span className="vf-field-error">{nuevoClienteErrors.correo}</span>}
               </div>
 
-              <div className="vf-form-group vf-full">
+              <div className="form-group vf-nc-full">
                 <label>Dirección <span className="required">*</span></label>
                 <input
                   name="direccion"
@@ -312,7 +350,7 @@ const VentaForm = ({ onClose, onSubmit, venta, preselectedUnidadId }) => {
                 {nuevoClienteErrors.direccion && <span className="vf-field-error">{nuevoClienteErrors.direccion}</span>}
               </div>
 
-              <div className="vf-form-group">
+              <div className="form-group">
                 <label>Departamento <span className="required">*</span></label>
                 <select name="departamento" value={nuevoCliente.departamento} onChange={handleNuevoClienteChange}>
                   <option value="">Selecciona...</option>
@@ -323,7 +361,7 @@ const VentaForm = ({ onClose, onSubmit, venta, preselectedUnidadId }) => {
                 {nuevoClienteErrors.departamento && <span className="vf-field-error">{nuevoClienteErrors.departamento}</span>}
               </div>
 
-              <div className="vf-form-group">
+              <div className="form-group">
                 <label>Ciudad <span className="required">*</span></label>
                 <select
                   name="ciudad"
@@ -332,7 +370,7 @@ const VentaForm = ({ onClose, onSubmit, venta, preselectedUnidadId }) => {
                   disabled={!nuevoCliente.departamento}
                 >
                   <option value="">
-                    {nuevoCliente.departamento ? "Selecciona..." : "Selecciona departamento primero"}
+                    {nuevoCliente.departamento ? "Selecciona..." : "Selecciona depto. primero"}
                   </option>
                   {ciudadesFiltradas.map((c) => (
                     <option key={c.id} value={c.id}>{c.nombre}</option>
@@ -350,10 +388,11 @@ const VentaForm = ({ onClose, onSubmit, venta, preselectedUnidadId }) => {
           <textarea
             id="notas"
             name="notas"
-            placeholder="Notas adicionales sobre la venta..."
+            placeholder="Notas adicionales..."
             value={formData.notas}
             onChange={handleChange}
-            rows="2"
+            rows="1"
+            className="vf-notas-compact"
           />
         </div>
 
@@ -361,90 +400,124 @@ const VentaForm = ({ onClose, onSubmit, venta, preselectedUnidadId }) => {
         <div className="vf-items-section">
           <h4>Agregar Items</h4>
           <div className="vf-add-item">
-            <div className="vf-add-item-group">
-              <label htmlFor="selectedUnidad">Unidad</label>
-              <select
-                id="selectedUnidad"
-                value={selectedUnidad}
-                onChange={(e) => {
-                  const unidad = unidades.find((u) => u.id === parseInt(e.target.value));
-                  setSelectedUnidad(e.target.value);
-                  if (unidad) setSelectedPrecio(unidad.precio);
-                }}
-              >
-                <option value="">Selecciona una unidad...</option>
-                {unidades
-                  .filter((u) => u.estado_venta === "sin_vender")
-                  .map((u) => (
-                    <option key={u.id} value={u.id}>
-                      {u.serial} - {u.producto_nombre}
-                    </option>
-                  ))}
-              </select>
-            </div>
-
-            <div className="vf-add-item-group">
-              <label htmlFor="selectedPrecio">Precio</label>
-              <input
-                id="selectedPrecio"
-                type="number"
-                step="0.01"
-                placeholder="Precio"
-                value={selectedPrecio}
-                onChange={(e) => setSelectedPrecio(e.target.value)}
-              />
-            </div>
-
-            <button type="button" className="vf-add-btn" onClick={handleAddItem}>
-              <Plus size={20} /> Agregar
-            </button>
-          </div>
-
-          {formData.items_data.length > 0 && (
-            <div className="vf-items-list">
-              <h5>Items agregados:</h5>
-              <table className="vf-items-table">
-                <thead>
-                  <tr>
-                    <th>Serial</th>
-                    <th>Producto</th>
-                    <th>Precio</th>
-                    <th>Acción</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {formData.items_data.map((item, idx) => (
-                    <tr key={idx}>
-                      <td>{item.unidad_serial}</td>
-                      <td>{item.producto_nombre}</td>
-                      <td>
-                        <input
-                          type="number"
-                          step="0.01"
-                          value={item.precio}
-                          onChange={(e) => handleUpdateItemPrice(idx, e.target.value)}
-                          className="vf-price-input"
-                        />
-                      </td>
-                      <td>
-                        <button
-                          type="button"
-                          className="vf-delete-btn"
-                          onClick={() => handleRemoveItem(idx)}
-                          title="Eliminar"
-                        >
-                          <Trash2 size={16} />
-                        </button>
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-              <div className="vf-total">
-                <strong>Total: ${total.toLocaleString("es-CO", { maximumFractionDigits: 0 })}</strong>
+            <div className="vf-add-item-group vf-add-item-full">
+              <label htmlFor="unidadSearch">Unidad</label>
+              <div className="vf-search-wrapper" ref={unidadSearchRef}>
+                <Search size={16} className="vf-search-icon" />
+                <input
+                  id="unidadSearch"
+                  type="text"
+                  placeholder="Buscar por serial o producto..."
+                  value={unidadSearch}
+                  onChange={(e) => {
+                    setUnidadSearch(e.target.value);
+                    setSelectedUnidad("");
+                    setSelectedPrecio("");
+                    setShowUnidadDropdown(true);
+                  }}
+                  onFocus={() => setShowUnidadDropdown(true)}
+                  autoComplete="off"
+                />
+                {showUnidadDropdown && filteredDropdownUnidades.length > 0 && (
+                  <div className="vf-search-dropdown">
+                    {filteredDropdownUnidades.slice(0, 8).map((u) => (
+                      <div
+                        key={u.id}
+                        className="vf-search-option"
+                        onMouseDown={(e) => {
+                          e.preventDefault();
+                          handleSelectUnidad(u);
+                        }}
+                      >
+                        <code className="vf-search-option-serial">{u.serial}</code>
+                        <span className="vf-search-option-name">{u.producto_nombre}</span>
+                        <span className="vf-search-option-price">${Number(u.precio).toLocaleString("es-CO")}</span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+                {showUnidadDropdown && unidadSearch.trim() && filteredDropdownUnidades.length === 0 && (
+                  <div className="vf-search-dropdown">
+                    <div className="vf-search-no-results">Sin resultados</div>
+                  </div>
+                )}
               </div>
             </div>
-          )}
+
+            <div className="vf-add-item-row">
+              <div className="vf-add-item-group vf-add-item-precio">
+                <label htmlFor="selectedPrecio">Precio</label>
+                <input
+                  id="selectedPrecio"
+                  type="number"
+                  step="0.01"
+                  placeholder="Precio"
+                  value={selectedPrecio}
+                  onChange={(e) => setSelectedPrecio(e.target.value)}
+                />
+              </div>
+
+              <button type="button" className="vf-add-btn" onClick={handleAddItem}>
+                <Plus size={18} /> Agregar
+              </button>
+            </div>
+          </div>
+
+          <div className="vf-items-list">
+            {formData.items_data.length === 0 ? (
+              <div className="vf-empty-state">
+                <ShoppingCart size={28} strokeWidth={1.5} />
+                <p>No hay items agregados</p>
+              </div>
+            ) : (
+              <>
+                <table className="vf-items-table">
+                  <thead>
+                    <tr>
+                      <th>Serial</th>
+                      <th>Producto</th>
+                      <th>Precio</th>
+                      <th></th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {formData.items_data.map((item, idx) => (
+                      <tr key={idx}>
+                        <td><code className="vf-serial-code">{item.unidad_serial}</code></td>
+                        <td>
+                          <span className="vf-product-name" title={item.producto_nombre}>
+                            {item.producto_nombre}
+                          </span>
+                        </td>
+                        <td>
+                          <input
+                            type="number"
+                            step="0.01"
+                            value={item.precio}
+                            onChange={(e) => handleUpdateItemPrice(idx, e.target.value)}
+                            className="vf-price-input"
+                          />
+                        </td>
+                        <td>
+                          <button
+                            type="button"
+                            className="vf-delete-btn"
+                            onClick={() => handleRemoveItem(idx)}
+                            title="Eliminar"
+                          >
+                            <Trash2 size={15} />
+                          </button>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+                <div className="vf-total">
+                  <strong>Total: ${total.toLocaleString("es-CO", { maximumFractionDigits: 0 })}</strong>
+                </div>
+              </>
+            )}
+          </div>
         </div>
       </div>
     </ModalBase>

--- a/gaming-laptop-store/src/pages/admin/ClienteDetail.jsx
+++ b/gaming-laptop-store/src/pages/admin/ClienteDetail.jsx
@@ -1,11 +1,25 @@
 import React, { useState, useEffect } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import { ArrowLeft, User, ShoppingCart, Clock } from "lucide-react";
+import { ArrowLeft, ShoppingCart, Clock } from "lucide-react";
 import DataTable from "../../components/admin/DataTable";
 import * as ClienteService from "../../services/ClienteService";
 import * as VentaService from "../../services/VentaService";
 import * as SeparacionService from "../../services/SeparacionService";
 import "../../styles/admin/clienteDetail.css";
+
+const getInitials = (name) => {
+  const parts = name.split(" ").filter(Boolean);
+  if (parts.length >= 2)
+    return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+  return parts[0]?.[0]?.toUpperCase() || "?";
+};
+
+const getAvatarColor = (name) => {
+  const colors = ["#4f46e5", "#0891b2", "#059669", "#d97706", "#dc2626", "#7c3aed", "#db2777"];
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) hash = name.charCodeAt(i) + ((hash << 5) - hash);
+  return colors[Math.abs(hash) % colors.length];
+};
 
 const ClienteDetail = () => {
   const { id } = useParams();
@@ -24,18 +38,15 @@ const ClienteDetail = () => {
   const loadData = async () => {
     setLoading(true);
     try {
-      // Load client details
       const clienteData = await ClienteService.getClienteDetail(id);
       setCliente(clienteData.cliente || clienteData);
 
-      // Load all ventas and filter by this client
       const ventasData = await VentaService.getVentas();
       const clientVentas = (Array.isArray(ventasData) ? ventasData : ventasData.ventas || []).filter(
         (v) => v.cliente === parseInt(id)
       );
       setVentas(clientVentas);
 
-      // Load all separaciones and filter by this client
       const separacionesData = await SeparacionService.getSeparaciones();
       const clientSeparaciones = (Array.isArray(separacionesData) ? separacionesData : separacionesData.separaciones || []).filter(
         (s) => s.cliente === parseInt(id)
@@ -133,18 +144,29 @@ const ClienteDetail = () => {
   return (
     <div className="cd-container">
       <div className="cd-header">
-        <button className="cd-back-btn" onClick={() => navigate("/admin/clientes")}>
-          <ArrowLeft size={20} />
+        <button
+          className="cd-back-btn"
+          onClick={() => navigate("/admin/clientes")}
+          aria-label="Volver al listado de clientes"
+        >
+          <ArrowLeft size={18} />
+          <span>Clientes</span>
         </button>
-        <h1>Detalles del Cliente</h1>
       </div>
 
       <div className="cd-info-card">
         <div className="cd-info-header">
-          <User size={28} />
+          <div
+            className="cd-avatar"
+            style={{ backgroundColor: getAvatarColor(cliente.nombre_completo) }}
+          >
+            {getInitials(cliente.nombre_completo)}
+          </div>
           <div className="cd-info-content">
             <h2>{cliente.nombre_completo}</h2>
-            <p className="cd-subtitle">ID: {cliente.id}</p>
+            <p className="cd-subtitle">
+              CC {cliente.cedula} &middot; {cliente.ciudad_nombre || "Sin ciudad"}, {cliente.departamento_nombre || ""}
+            </p>
           </div>
         </div>
 
@@ -155,11 +177,19 @@ const ClienteDetail = () => {
           </div>
           <div className="cd-info-item">
             <label>Celular</label>
-            <p>{cliente.celular}</p>
+            <p>
+              <a href={`tel:${cliente.celular}`} className="cd-link">
+                {cliente.celular}
+              </a>
+            </p>
           </div>
           <div className="cd-info-item">
             <label>Correo</label>
-            <p>{cliente.correo}</p>
+            <p>
+              <a href={`mailto:${cliente.correo}`} className="cd-link">
+                {cliente.correo}
+              </a>
+            </p>
           </div>
           <div className="cd-info-item">
             <label>Ciudad</label>
@@ -169,7 +199,7 @@ const ClienteDetail = () => {
             <label>Departamento</label>
             <p>{cliente.departamento_nombre || "N/A"}</p>
           </div>
-          <div className="cd-info-item cd-full">
+          <div className="cd-info-item">
             <label>Dirección</label>
             <p>{cliente.direccion}</p>
           </div>
@@ -196,23 +226,53 @@ const ClienteDetail = () => {
       <div className="cd-content">
         {activeTab === "ventas" && (
           <div className="cd-table-container">
-            <h3>Historial de Ventas</h3>
-            <DataTable
-              columns={ventasColumns}
-              data={ventas}
-              emptyMessage="No hay ventas registradas para este cliente"
-            />
+            {ventas.length === 0 ? (
+              <div className="cd-empty-state">
+                <ShoppingCart size={48} strokeWidth={1} />
+                <p className="cd-empty-title">Sin ventas registradas</p>
+                <p className="cd-empty-desc">
+                  Este cliente aún no tiene compras. Puedes crear una desde el módulo de ventas.
+                </p>
+                <button
+                  className="cd-empty-action"
+                  onClick={() => navigate("/admin/ventas")}
+                >
+                  Ir a Ventas
+                </button>
+              </div>
+            ) : (
+              <DataTable
+                columns={ventasColumns}
+                data={ventas}
+                emptyMessage="No hay ventas registradas para este cliente"
+              />
+            )}
           </div>
         )}
 
         {activeTab === "separaciones" && (
           <div className="cd-table-container">
-            <h3>Historial de Separaciones</h3>
-            <DataTable
-              columns={separacionesColumns}
-              data={separaciones}
-              emptyMessage="No hay separaciones registradas para este cliente"
-            />
+            {separaciones.length === 0 ? (
+              <div className="cd-empty-state">
+                <Clock size={48} strokeWidth={1} />
+                <p className="cd-empty-title">Sin separaciones registradas</p>
+                <p className="cd-empty-desc">
+                  Este cliente no tiene separaciones. Puedes crear una desde el módulo de separaciones.
+                </p>
+                <button
+                  className="cd-empty-action"
+                  onClick={() => navigate("/admin/separaciones")}
+                >
+                  Ir a Separaciones
+                </button>
+              </div>
+            ) : (
+              <DataTable
+                columns={separacionesColumns}
+                data={separaciones}
+                emptyMessage="No hay separaciones registradas para este cliente"
+              />
+            )}
           </div>
         )}
       </div>

--- a/gaming-laptop-store/src/pages/admin/Clientes.jsx
+++ b/gaming-laptop-store/src/pages/admin/Clientes.jsx
@@ -118,7 +118,8 @@ const Clientes = () => {
     { key: "cedula", label: "Cédula" },
     { key: "celular", label: "Celular" },
     { key: "correo", label: "Correo" },
-    { key: "ciudad", label: "Ciudad" },
+    { key: "ciudad_nombre", label: "Ciudad" },
+    { key: "departamento_nombre", label: "Departamento" },
   ];
 
   const stats = [

--- a/gaming-laptop-store/src/pages/admin/Unidades.jsx
+++ b/gaming-laptop-store/src/pages/admin/Unidades.jsx
@@ -408,7 +408,7 @@ const Unidades = () => {
           columns={columns}
           data={filteredUnidades}
           rowKey="id"
-          onEdit={handleOpenModal}
+          onEdit={(row) => handleOpenModal(row)}
           customActions={[
             {
               icon: FaShoppingCart,

--- a/gaming-laptop-store/src/styles/admin/clienteDetail.css
+++ b/gaming-laptop-store/src/styles/admin/clienteDetail.css
@@ -14,26 +14,21 @@
 .cd-back-btn {
   display: flex;
   align-items: center;
-  justify-content: center;
-  width: 40px;
-  height: 40px;
-  padding: 0;
+  gap: 0.5rem;
+  height: 44px;
+  padding: 0 1rem;
   background-color: #f3f4f6;
   border: 1px solid #e5e7eb;
   border-radius: 6px;
   cursor: pointer;
   color: #374151;
+  font-size: 0.875rem;
+  font-weight: 500;
   transition: all 0.2s;
 }
 
 .cd-back-btn:hover {
   background-color: #e5e7eb;
-  color: #1f2937;
-}
-
-.cd-header h1 {
-  margin: 0;
-  font-size: 1.875rem;
   color: #1f2937;
 }
 
@@ -54,9 +49,18 @@
   border-bottom: 1px solid #e5e7eb;
 }
 
-.cd-info-header svg {
-  color: #4f46e5;
+.cd-avatar {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: white;
+  font-weight: 700;
+  font-size: 1.1rem;
   flex-shrink: 0;
+  letter-spacing: 0.02em;
 }
 
 .cd-info-content h2 {
@@ -73,7 +77,7 @@
 
 .cd-info-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  grid-template-columns: repeat(3, 1fr);
   gap: 1.5rem;
 }
 
@@ -82,23 +86,30 @@
   flex-direction: column;
 }
 
-.cd-info-item.cd-full {
-  grid-column: 1 / -1;
-}
-
 .cd-info-item label {
   margin-bottom: 0.5rem;
   font-weight: 600;
   color: #6b7280;
   font-size: 0.85rem;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.08em;
 }
 
 .cd-info-item p {
   margin: 0;
   color: #1f2937;
   font-size: 0.95rem;
+}
+
+.cd-link {
+  color: #4f46e5;
+  text-decoration: none;
+  transition: color 0.2s;
+}
+
+.cd-link:hover {
+  color: #4338ca;
+  text-decoration: underline;
 }
 
 .cd-tabs {
@@ -140,11 +151,56 @@
 }
 
 .cd-table-container {
-  padding: 2rem;
+  padding: 1.25rem 2rem 2rem;
 }
 
-.cd-table-container h3 {
+/* Empty state */
+.cd-empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 3rem 2rem;
+  color: #9ca3af;
+}
+
+.cd-empty-state svg {
+  color: #d1d5db;
+  margin-bottom: 1rem;
+}
+
+.cd-empty-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #6b7280;
+  margin: 0 0 0.5rem 0;
+}
+
+.cd-empty-desc {
+  font-size: 0.875rem;
+  color: #9ca3af;
   margin: 0 0 1.5rem 0;
-  font-size: 1.1rem;
-  color: #1f2937;
+  text-align: center;
+  max-width: 360px;
+}
+
+.cd-empty-action {
+  padding: 0.5rem 1.25rem;
+  background-color: #4f46e5;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.cd-empty-action:hover {
+  background-color: #4338ca;
+}
+
+@media (max-width: 768px) {
+  .cd-info-grid {
+    grid-template-columns: 1fr;
+  }
 }

--- a/gaming-laptop-store/src/styles/admin/clientesForm.css
+++ b/gaming-laptop-store/src/styles/admin/clientesForm.css
@@ -2,48 +2,14 @@
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 1rem;
-  margin-bottom: 1.5rem;
 }
 
-.cf-form-group {
-  display: flex;
-  flex-direction: column;
-}
-
-.cf-form-group.cf-full {
+.cf-full {
   grid-column: 1 / -1;
 }
 
-.cf-form-group label {
-  margin-bottom: 0.5rem;
-  font-weight: 500;
-  color: #333;
-  font-size: 0.9rem;
-}
-
-.cf-form-group input,
-.cf-form-group select {
-  padding: 0.75rem;
-  border: 1px solid #ddd;
-  border-radius: 4px;
-  font-size: 0.9rem;
-  font-family: inherit;
-  transition: border-color 0.2s;
-}
-
-.cf-form-group input:focus,
-.cf-form-group select:focus {
-  outline: none;
-  border-color: #4f46e5;
-  box-shadow: 0 0 0 3px rgba(79, 70, 229, 0.1);
-}
-
-.cf-form-group select:disabled {
-  background-color: #f5f5f5;
-  color: #999;
-  cursor: not-allowed;
-}
-
-.required {
-  color: #ef4444;
+@media (max-width: 500px) {
+  .cf-form-grid {
+    grid-template-columns: 1fr;
+  }
 }

--- a/gaming-laptop-store/src/styles/admin/unidadForm.css
+++ b/gaming-laptop-store/src/styles/admin/unidadForm.css
@@ -47,6 +47,19 @@
   margin-bottom: 0.25rem;
 }
 
+/* ── Locked unit banner ─────────────────────────────────── */
+
+.uf-locked-banner {
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  border-radius: 6px;
+  padding: 0.7rem 0.85rem;
+  font-size: 0.85rem;
+  color: #991b1b;
+  line-height: 1.5;
+  margin-bottom: 0.5rem;
+}
+
 /* ── Form grid — two columns ────────────────────────────── */
 
 .uf-grid {

--- a/gaming-laptop-store/src/styles/admin/ventaForm.css
+++ b/gaming-laptop-store/src/styles/admin/ventaForm.css
@@ -1,3 +1,9 @@
+/* Wider modal for VentaForm */
+.vf-modal-wide {
+  width: 650px;
+  overflow-x: hidden;
+}
+
 .vf-form-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
@@ -10,14 +16,15 @@
   flex-direction: column;
 }
 
-.vf-form-group.vf-full {
+.vf-form-group.vf-full,
+.vf-full {
   grid-column: 1 / -1;
 }
 
 .vf-form-group label {
   margin-bottom: 0.5rem;
   font-weight: 500;
-  color: #333;
+  color: var(--text-color, #333);
   font-size: 0.9rem;
 }
 
@@ -25,10 +32,12 @@
 .vf-form-group select,
 .vf-form-group textarea {
   padding: 0.75rem;
-  border: 1px solid #ddd;
-  border-radius: 4px;
+  border: 1px solid var(--fourth-color, #ddd);
+  border-radius: 8px;
   font-size: 0.9rem;
   font-family: inherit;
+  background-color: var(--card-bg);
+  color: var(--text-color);
   transition: border-color 0.2s;
 }
 
@@ -36,13 +45,19 @@
 .vf-form-group select:focus,
 .vf-form-group textarea:focus {
   outline: none;
-  border-color: #4f46e5;
-  box-shadow: 0 0 0 3px rgba(79, 70, 229, 0.1);
+  border-color: var(--primary-color);
+  box-shadow: 0 0 0 3px rgba(41, 121, 200, 0.12);
 }
 
 .vf-form-group textarea {
   resize: vertical;
   min-height: 80px;
+}
+
+/* Compact notas textarea */
+.vf-notas-compact {
+  min-height: 36px !important;
+  resize: vertical;
 }
 
 .required {
@@ -90,14 +105,27 @@
 .vf-nuevo-cliente {
   border: 1px solid var(--fourth-color);
   border-radius: 8px;
-  padding: 1rem;
-  background: var(--bg-color);
+  padding: 0.85rem;
+  background: var(--card-bg);
+  width: 100%;
+  box-sizing: border-box;
 }
 
 .vf-nuevo-cliente-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 0.75rem 1rem;
+  gap: 0.6rem 0.85rem;
+  width: 100%;
+}
+
+.vf-nuevo-cliente-grid .vf-nc-full {
+  grid-column: 1 / -1;
+}
+
+.vf-nuevo-cliente-grid .form-group input,
+.vf-nuevo-cliente-grid .form-group select {
+  width: 100%;
+  box-sizing: border-box;
 }
 
 .vf-field-error {
@@ -109,25 +137,40 @@
 /* Items section */
 .vf-items-section {
   grid-column: 1 / -1;
-  border-top: 1px solid #eee;
-  padding-top: 1.5rem;
+  border-top: 1px solid var(--fourth-color, #eee);
+  padding-top: 1.25rem;
 }
 
 .vf-items-section h4 {
-  margin: 0 0 1rem 0;
+  margin: 0 0 0.75rem 0;
   font-size: 1rem;
-  color: #333;
+  color: var(--text-color, #333);
 }
 
+/* Add item: vertical stack layout */
 .vf-add-item {
-  display: grid;
-  grid-template-columns: 1fr 1fr auto;
-  gap: 1rem;
-  margin-bottom: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-bottom: 1.25rem;
   padding: 1rem;
-  background-color: #f9fafb;
-  border-radius: 4px;
+  background-color: var(--card-bg, #f9fafb);
+  border: 1px solid var(--fourth-color, #e5e7eb);
+  border-radius: 8px;
+}
+
+.vf-add-item-full {
+  width: 100%;
+}
+
+.vf-add-item-row {
+  display: flex;
+  gap: 0.75rem;
   align-items: flex-end;
+}
+
+.vf-add-item-precio {
+  flex: 1;
 }
 
 .vf-add-item-group {
@@ -136,111 +179,234 @@
 }
 
 .vf-add-item-group label {
-  margin-bottom: 0.5rem;
-  font-weight: 500;
-  color: #333;
-  font-size: 0.9rem;
+  margin-bottom: 0.4rem;
+  font-weight: 600;
+  color: var(--text-color, #333);
+  font-size: 0.85rem;
 }
 
 .vf-add-item-group input,
 .vf-add-item-group select {
-  padding: 0.75rem;
-  border: 1px solid #ddd;
-  border-radius: 4px;
+  padding: 0.65rem 0.75rem;
+  border: 1px solid var(--fourth-color, #ddd);
+  border-radius: 8px;
   font-size: 0.9rem;
   font-family: inherit;
   transition: border-color 0.2s;
+  background: var(--bg-color, #fff);
+  color: var(--text-color);
 }
 
 .vf-add-item-group input:focus,
 .vf-add-item-group select:focus {
   outline: none;
-  border-color: #4f46e5;
-  box-shadow: 0 0 0 3px rgba(79, 70, 229, 0.1);
+  border-color: var(--primary-color, #4f46e5);
+  box-shadow: 0 0 0 3px rgba(41, 121, 200, 0.12);
 }
 
 .vf-add-btn {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.75rem 1.5rem;
-  background-color: #4f46e5;
+  gap: 0.4rem;
+  padding: 0.65rem 1.25rem;
+  background-color: var(--cta-bg, #4f46e5);
   color: white;
   border: none;
-  border-radius: 4px;
-  font-size: 0.9rem;
-  font-weight: 500;
+  border-radius: 8px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  font-family: inherit;
   cursor: pointer;
   transition: background-color 0.2s;
+  white-space: nowrap;
 }
 
 .vf-add-btn:hover {
-  background-color: #4338ca;
+  background-color: var(--cta-hover, #4338ca);
 }
 
 .vf-add-btn:active {
-  background-color: #3730a3;
+  background-color: var(--cta-active, #3730a3);
 }
 
-/* Items list table */
+/* ── Searchable unit combobox ── */
+.vf-search-wrapper {
+  position: relative;
+}
+
+.vf-search-wrapper input {
+  width: 100%;
+  padding-left: 2.2rem;
+  box-sizing: border-box;
+}
+
+.vf-search-icon {
+  position: absolute;
+  left: 0.7rem;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--subtitle-color, #999);
+  pointer-events: none;
+}
+
+.vf-search-dropdown {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  z-index: 50;
+  max-height: 200px;
+  overflow-y: auto;
+  background: var(--bg-color, #fff);
+  border: 1px solid var(--fourth-color, #ddd);
+  border-top: none;
+  border-radius: 0 0 8px 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.vf-search-option {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.55rem 0.75rem;
+  cursor: pointer;
+  font-size: 0.83rem;
+  transition: background 0.1s;
+  border-bottom: 1px solid var(--fourth-color, #f0f0f0);
+}
+
+.vf-search-option:last-child {
+  border-bottom: none;
+}
+
+.vf-search-option:hover {
+  background: var(--icon-bg, #f3f4f6);
+}
+
+.vf-search-option-serial {
+  font-family: "Courier New", monospace;
+  font-size: 0.78rem;
+  font-weight: 600;
+  background: var(--icon-bg, #e5e7eb);
+  padding: 0.1rem 0.35rem;
+  border-radius: 4px;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.vf-search-option-name {
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--text-color, #333);
+}
+
+.vf-search-option-price {
+  color: var(--primary-color, #2979c8);
+  font-weight: 600;
+  font-size: 0.8rem;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.vf-search-no-results {
+  padding: 0.75rem;
+  text-align: center;
+  color: var(--subtitle-color, #999);
+  font-size: 0.83rem;
+}
+
+/* Items list & table */
 .vf-items-list {
-  overflow-x: auto;
-}
-
-.vf-items-list h5 {
-  margin: 1.5rem 0 1rem 0;
-  font-size: 0.95rem;
-  color: #333;
+  overflow-x: hidden;
 }
 
 .vf-items-table {
   width: 100%;
   border-collapse: collapse;
-  font-size: 0.9rem;
+  font-size: 0.85rem;
+  table-layout: fixed;
 }
 
 .vf-items-table thead {
-  background-color: #f3f4f6;
-  border-bottom: 2px solid #ddd;
+  background-color: var(--card-bg, #f3f4f6);
+  border-bottom: 2px solid var(--fourth-color, #ddd);
 }
 
 .vf-items-table th {
-  padding: 0.75rem;
+  padding: 0.6rem 0.5rem;
   text-align: left;
   font-weight: 600;
-  color: #333;
+  color: var(--text-color, #333);
+  font-size: 0.8rem;
 }
 
+/* Column widths */
+.vf-items-table th:nth-child(1) { width: 28%; }
+.vf-items-table th:nth-child(2) { width: 34%; }
+.vf-items-table th:nth-child(3) { width: 28%; }
+.vf-items-table th:nth-child(4) { width: 10%; }
+
 .vf-items-table td {
-  padding: 0.75rem;
-  border-bottom: 1px solid #eee;
+  padding: 0.5rem;
+  border-bottom: 1px solid var(--fourth-color, #eee);
+  overflow: hidden;
 }
 
 .vf-items-table tbody tr:hover {
-  background-color: #f9fafb;
+  background-color: var(--card-bg, #f9fafb);
+}
+
+/* Serial code style */
+.vf-serial-code {
+  font-family: "Courier New", monospace;
+  font-size: 0.78rem;
+  font-weight: 600;
+  background: var(--icon-bg, #f0f0f0);
+  padding: 0.15rem 0.4rem;
+  border-radius: 4px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: inline-block;
+  max-width: 100%;
+}
+
+/* Product name truncation with tooltip */
+.vf-product-name {
+  display: block;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+  cursor: default;
 }
 
 .vf-price-input {
   width: 100%;
-  padding: 0.5rem;
-  border: 1px solid #ddd;
+  padding: 0.4rem 0.5rem;
+  border: 1px solid var(--fourth-color, #ddd);
   border-radius: 4px;
-  font-size: 0.9rem;
+  font-size: 0.85rem;
   font-family: inherit;
+  box-sizing: border-box;
+  background: var(--bg-color, #fff);
+  color: var(--text-color);
 }
 
 .vf-price-input:focus {
   outline: none;
-  border-color: #4f46e5;
-  box-shadow: 0 0 0 2px rgba(79, 70, 229, 0.1);
+  border-color: var(--primary-color, #4f46e5);
+  box-shadow: 0 0 0 2px rgba(41, 121, 200, 0.12);
 }
 
 .vf-delete-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 32px;
-  height: 32px;
+  width: 28px;
+  height: 28px;
   padding: 0;
   background-color: #fee2e2;
   color: #dc2626;
@@ -258,17 +424,34 @@
   background-color: #fca5a5;
 }
 
+/* Empty state */
+.vf-empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 1.5rem 1rem;
+  color: var(--subtitle-color, #999);
+  border: 1px dashed var(--fourth-color, #ddd);
+  border-radius: 8px;
+}
+
+.vf-empty-state p {
+  margin: 0;
+  font-size: 0.85rem;
+}
+
 /* Total section */
 .vf-total {
-  margin-top: 1rem;
-  padding: 1rem;
+  margin-top: 0.75rem;
+  padding: 0.75rem 1rem;
   background-color: #f0f9ff;
-  border-left: 4px solid #4f46e5;
+  border-left: 4px solid var(--primary-color, #4f46e5);
   border-radius: 4px;
   text-align: right;
 }
 
 .vf-total strong {
   color: #1e40af;
-  font-size: 1.1rem;
+  font-size: 1.05rem;
 }


### PR DESCRIPTION
- Fix empty client dropdown (response parsed as .cliente instead of array)
- Add searchable unit combobox with serial/product filtering
- Exclude already-added units from dropdown selection
- Restructure VentaForm layout: wider modal, vertical item stack, empty state
- Align nuevo-cliente sub-form inputs with modal design system (form-group classes)
- Add ModalBase className prop for per-form width customization
- Lock editing of vendido/separado units with banner message
- Improve ClienteDetail with avatar, grid layout, and clickable links
- Fix Clientes table: show ciudad/departamento names instead of IDs
- Fix ClientesForm modal overflow with standard form-group classes