### PR TITLE
feat(prestamo): sección admin de Control de Préstamo

### DIFF
--- a/gaming-laptop-store/src/components/admin/AdminSidebar.jsx
+++ b/gaming-laptop-store/src/components/admin/AdminSidebar.jsx
@@ -22,10 +22,38 @@ import {
   ShieldCheck,
   Timer,
   RefreshCw,
+  Landmark,
+  History,
+  TableProperties,
 } from "lucide-react";
 import "../../styles/admin/adminSidebar.css";
 
 const NAV_SECTIONS = [
+  {
+    label: "Préstamo",
+    items: [
+      {
+        path: "/admin/prestamo",
+        icon: Landmark,
+        label: "Resumen",
+      },
+      {
+        path: "/admin/prestamo/movimientos",
+        icon: History,
+        label: "Movimientos",
+      },
+      {
+        path: "/admin/prestamo/proyeccion",
+        icon: TableProperties,
+        label: "Proyección",
+      },
+      {
+        path: "/admin/prestamo/auditoria",
+        icon: ShieldCheck,
+        label: "Auditoría",
+      },
+    ],
+  },
   {
     label: "Gestión",
     items: [

--- a/gaming-laptop-store/src/components/admin/MovimientoPrestamoForm.jsx
+++ b/gaming-laptop-store/src/components/admin/MovimientoPrestamoForm.jsx
@@ -1,0 +1,147 @@
+import React, { useState } from "react";
+import { Wallet } from "lucide-react";
+import ModalBase from "./ModalBase";
+import { uploadComprobante } from "../../services/PrestamoService";
+import { TIPO_OPTIONS, hoyISO } from "../../pages/admin/Prestamo/prestamoUtils";
+
+/**
+ * Formulario modal para crear/editar un movimiento del préstamo.
+ * El `tramo` se deriva del tipo en el backend; aquí solo se elige el tipo.
+ */
+const MovimientoPrestamoForm = ({
+  onClose,
+  onSubmit,
+  movimiento = null,
+  isSubmitting = false,
+  submitError = null,
+}) => {
+  // Al crear de forma eventual solo se permiten abonos (las cuotas y el 2% se
+  // registran juntas con "Realizar pago regular"). Al editar se muestran todos
+  // los tipos para no perder el del movimiento existente.
+  const opciones = movimiento
+    ? TIPO_OPTIONS
+    : TIPO_OPTIONS.filter((o) => o.value.startsWith("abono_"));
+  const [tipo, setTipo] = useState(movimiento?.tipo || "abono_amigo");
+  const [monto, setMonto] = useState(movimiento?.monto || "");
+  const [fecha, setFecha] = useState(movimiento?.fecha || hoyISO());
+  const [nota, setNota] = useState(movimiento?.nota || "");
+  const [comprobanteUrl, setComprobanteUrl] = useState(
+    movimiento?.comprobante_url || ""
+  );
+  const [uploading, setUploading] = useState(false);
+  const [localError, setLocalError] = useState(null);
+
+  const handleFile = async (e) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setUploading(true);
+    setLocalError(null);
+    try {
+      const url = await uploadComprobante(file);
+      setComprobanteUrl(url);
+    } catch (err) {
+      console.error("Error subiendo comprobante:", err);
+      setLocalError("No se pudo subir el comprobante.");
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const handleSubmit = () => {
+    setLocalError(null);
+    const montoNum = Number(monto);
+    if (!Number.isFinite(montoNum) || montoNum <= 0) {
+      setLocalError("El monto debe ser mayor que 0.");
+      return;
+    }
+    if (!fecha) {
+      setLocalError("La fecha es obligatoria.");
+      return;
+    }
+    const payload = {
+      tipo,
+      monto: String(monto),
+      fecha,
+      nota,
+      comprobante_url: comprobanteUrl,
+    };
+    onSubmit(payload, movimiento?.id);
+  };
+
+  return (
+    <ModalBase
+      title={movimiento ? "Editar movimiento" : "Registrar abono"}
+      icon={<Wallet size={20} />}
+      onClose={onClose}
+      onSubmit={handleSubmit}
+      isSubmitting={isSubmitting || uploading}
+      submitLabel={movimiento ? "Guardar cambios" : "+ Registrar"}
+    >
+      <div className="pr-form-grid">
+        <label className="pr-field">
+          <span>Tipo de movimiento</span>
+          <select value={tipo} onChange={(e) => setTipo(e.target.value)}>
+            {opciones.map((o) => (
+              <option key={o.value} value={o.value}>
+                {o.label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="pr-field">
+          <span>Monto (COP)</span>
+          <input
+            type="number"
+            min="0"
+            step="0.01"
+            value={monto}
+            onChange={(e) => setMonto(e.target.value)}
+            placeholder="0"
+          />
+        </label>
+
+        <label className="pr-field">
+          <span>Fecha</span>
+          <input
+            type="date"
+            value={fecha}
+            onChange={(e) => setFecha(e.target.value)}
+          />
+        </label>
+
+        <label className="pr-field pr-field--full">
+          <span>Nota (opcional)</span>
+          <textarea
+            rows={2}
+            value={nota}
+            onChange={(e) => setNota(e.target.value)}
+            placeholder="Detalle del movimiento…"
+          />
+        </label>
+
+        <label className="pr-field pr-field--full">
+          <span>Comprobante (opcional)</span>
+          <input type="file" onChange={handleFile} />
+          {uploading && <small className="pr-hint">Subiendo…</small>}
+          {comprobanteUrl && (
+            <a
+              href={comprobanteUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="pr-link"
+            >
+              Ver comprobante adjunto
+            </a>
+          )}
+        </label>
+      </div>
+
+      {(localError || submitError) && (
+        <p className="pr-error">{localError || submitError}</p>
+      )}
+    </ModalBase>
+  );
+};
+
+export default MovimientoPrestamoForm;

--- a/gaming-laptop-store/src/components/admin/PagoRegularModal.jsx
+++ b/gaming-laptop-store/src/components/admin/PagoRegularModal.jsx
@@ -1,0 +1,151 @@
+import React, { useState } from "react";
+import { CalendarCheck, User, UserCog, Percent } from "lucide-react";
+import ModalBase from "./ModalBase";
+import {
+  usePagoRegularPreview,
+  useRegistrarPagoRegular,
+} from "../../pages/admin/Prestamo/usePrestamo";
+import { formatCOP2 } from "../../pages/admin/Prestamo/prestamoUtils";
+import { uploadComprobante } from "../../services/PrestamoService";
+
+/**
+ * Registra de una sola vez las 3 líneas del corte del día 11:
+ *  - cuota del amigo al préstamo
+ *  - cuota del dueño al préstamo
+ *  - 2% que el amigo paga al dueño
+ * Los montos los calcula el motor para el período vigente.
+ */
+const PagoRegularModal = ({ onClose }) => {
+  const { data: preview, isLoading, isError } = usePagoRegularPreview(true);
+  const mut = useRegistrarPagoRegular();
+  const [error, setError] = useState(null);
+  const [comprobanteUrl, setComprobanteUrl] = useState("");
+  const [uploading, setUploading] = useState(false);
+
+  const yaPagado = preview?.ya_pagado;
+
+  const handleFile = async (e) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setUploading(true);
+    setError(null);
+    try {
+      const url = await uploadComprobante(file);
+      setComprobanteUrl(url);
+    } catch (err) {
+      console.error("Error subiendo comprobante:", err);
+      setError("No se pudo subir el comprobante.");
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const handleConfirm = async () => {
+    setError(null);
+    try {
+      // período vigente (default del backend) + comprobante opcional
+      await mut.mutateAsync({ comprobanteUrl });
+      onClose();
+    } catch (e) {
+      setError(e.response?.data?.message || "No se pudo registrar el pago regular.");
+    }
+  };
+
+  const lineas = preview
+    ? [
+        {
+          icon: <User size={16} />,
+          label: "Cuota del amigo → préstamo",
+          valor: preview.cuota_amigo,
+        },
+        {
+          icon: <UserCog size={16} />,
+          label: "Tu cuota → préstamo",
+          valor: preview.cuota_dueno,
+        },
+        {
+          icon: <Percent size={16} />,
+          label: "Comisión 2% del amigo → a ti",
+          valor: preview.comision_2pct,
+        },
+      ]
+    : [];
+
+  const fechaTxt = preview?.fecha
+    ? new Date(preview.fecha + "T00:00:00").toLocaleDateString("es-CO")
+    : "";
+
+  return (
+    <ModalBase
+      title="Realizar pago regular"
+      icon={<CalendarCheck size={20} />}
+      onClose={onClose}
+      onSubmit={!isLoading && !yaPagado && !isError ? handleConfirm : undefined}
+      isSubmitting={mut.isPending || uploading}
+      submitLabel="Confirmar pago"
+      subtitle={
+        preview && preview.configurado !== false
+          ? `Corte del mes ${preview.mes} · ${fechaTxt}`
+          : undefined
+      }
+    >
+      {isLoading && <p className="pr-muted">Calculando montos del corte…</p>}
+
+      {isError && (
+        <p className="pr-error">No se pudo cargar el pago regular.</p>
+      )}
+
+      {preview && preview.configurado === false && (
+        <p className="pr-muted">Aún no hay configuración del préstamo.</p>
+      )}
+
+      {preview && preview.configurado !== false && (
+        <>
+          {yaPagado && (
+            <div className="pr-notice pr-notice--warn">
+              El pago regular del mes {preview.mes} ya fue registrado.
+            </div>
+          )}
+
+          <ul className="pr-pago-list">
+            {lineas.map((l, i) => (
+              <li key={i} className="pr-pago-row">
+                <span className="pr-pago-label">{l.icon} {l.label}</span>
+                <span className="pr-pago-val">{formatCOP2(l.valor)}</span>
+              </li>
+            ))}
+            <li className="pr-pago-row pr-pago-row--total">
+              <span className="pr-pago-label">Total del corte</span>
+              <span className="pr-pago-val">{formatCOP2(preview.total)}</span>
+            </li>
+          </ul>
+
+          {!yaPagado && (
+            <label className="pr-field pr-field--full" style={{ marginTop: "0.5rem" }}>
+              <span>Comprobante (opcional)</span>
+              <input type="file" onChange={handleFile} disabled={uploading} />
+              {uploading && <small className="pr-hint">Subiendo…</small>}
+              {comprobanteUrl && (
+                <a href={comprobanteUrl} target="_blank" rel="noreferrer" className="pr-link">
+                  Ver comprobante adjunto
+                </a>
+              )}
+            </label>
+          )}
+
+          {!yaPagado && (
+            <p className="pr-hint">
+              Se crearán 3 movimientos con fecha {fechaTxt}
+              {comprobanteUrl ? ", con el comprobante adjunto" : ""}. Los abonos
+              adicionales se registran aparte.
+            </p>
+          )}
+        </>
+      )}
+
+      {error && <p className="pr-error">{error}</p>}
+    </ModalBase>
+  );
+};
+
+export default PagoRegularModal;

--- a/gaming-laptop-store/src/main.jsx
+++ b/gaming-laptop-store/src/main.jsx
@@ -43,6 +43,10 @@ import MonitoredProductDetail from "./pages/admin/MonitoredProductDetail.jsx";
 import TrustedSellers from "./pages/admin/TrustedSellers.jsx";
 import DealWatcherConfig from "./pages/admin/DealWatcherConfig.jsx";
 import SyncBajoPedidoMonitor from "./pages/admin/SyncBajoPedidoMonitor.jsx";
+import PrestamoDashboard from "./pages/admin/Prestamo/PrestamoDashboard.jsx";
+import PrestamoMovimientos from "./pages/admin/Prestamo/PrestamoMovimientos.jsx";
+import PrestamoProyeccion from "./pages/admin/Prestamo/PrestamoProyeccion.jsx";
+import PrestamoAuditoria from "./pages/admin/Prestamo/PrestamoAuditoria.jsx";
 
 
 const router = createBrowserRouter([
@@ -65,7 +69,11 @@ const router = createBrowserRouter([
   {
     element: <AdminLayout />,
     children: [
-      { path: "/admin", element: <Navigate to="/admin/dashboard" replace /> },
+      { path: "/admin", element: <Navigate to="/admin/prestamo" replace /> },
+      { path: "/admin/prestamo", element: <PrestamoDashboard /> },
+      { path: "/admin/prestamo/movimientos", element: <PrestamoMovimientos /> },
+      { path: "/admin/prestamo/proyeccion", element: <PrestamoProyeccion /> },
+      { path: "/admin/prestamo/auditoria", element: <PrestamoAuditoria /> },
       { path: "/admin/dashboard", element: <Dashboard /> },
       { path: "/admin/ganancia-neta", element: <GananciaNeta /> },
       { path: "/admin/ordenes-envio", element: <OrdenesEnvio /> },

--- a/gaming-laptop-store/src/pages/admin/Prestamo/PrestamoAuditoria.jsx
+++ b/gaming-laptop-store/src/pages/admin/Prestamo/PrestamoAuditoria.jsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { ShieldCheck } from "lucide-react";
+
+import TitleCrud from "../../../components/admin/TitleCrud";
+import DataTable from "../../../components/admin/DataTable";
+import { useAuditoria } from "./usePrestamo";
+import "../../../styles/admin/prestamo.css";
+
+const ACCION_LABELS = { crear: "Creó", editar: "Editó", borrar: "Borró" };
+
+function resumenCambio(row) {
+  const after = row.valores_despues;
+  const before = row.valores_antes;
+  const ref = after || before || {};
+  const partes = [];
+  if (ref.tipo) partes.push(ref.tipo);
+  if (ref.monto) partes.push(`$${ref.monto}`);
+  if (ref.fecha) partes.push(ref.fecha);
+  return partes.join(" · ") || "—";
+}
+
+const PrestamoAuditoria = () => {
+  const { data: auditoria = [], isLoading } = useAuditoria();
+
+  const columns = [
+    {
+      key: "timestamp",
+      label: "Fecha/hora",
+      render: (r) => new Date(r.timestamp).toLocaleString("es-CO"),
+    },
+    { key: "usuario_email", label: "Usuario", render: (r) => r.usuario_email || "—" },
+    {
+      key: "accion",
+      label: "Acción",
+      render: (r) => (
+        <span className={`pr-badge pr-badge--${r.accion}`}>
+          {ACCION_LABELS[r.accion] || r.accion}
+        </span>
+      ),
+    },
+    { key: "modelo", label: "Entidad", render: (r) => `${r.modelo}#${r.objeto_id}` },
+    { key: "detalle", label: "Detalle", render: resumenCambio },
+  ];
+
+  return (
+    <section className="pr-page">
+      <TitleCrud
+        title="Auditoría"
+        icon={ShieldCheck}
+        description="Bitácora inmutable de todos los cambios (solo lectura)"
+      />
+
+      {isLoading ? (
+        <p className="pr-muted">Cargando auditoría…</p>
+      ) : (
+        <DataTable columns={columns} data={auditoria} rowKey="id" showEdit={false} />
+      )}
+    </section>
+  );
+};
+
+export default PrestamoAuditoria;

--- a/gaming-laptop-store/src/pages/admin/Prestamo/PrestamoDashboard.jsx
+++ b/gaming-laptop-store/src/pages/admin/Prestamo/PrestamoDashboard.jsx
@@ -1,0 +1,138 @@
+import React, { useState } from "react";
+import { Link } from "react-router-dom";
+import {
+  Landmark,
+  User,
+  UserCog,
+  CalendarClock,
+  Receipt,
+  Percent,
+  Plus,
+  TableProperties,
+  History,
+  CalendarCheck,
+} from "lucide-react";
+
+import TitleCrud from "../../../components/admin/TitleCrud";
+import MovimientoPrestamoForm from "../../../components/admin/MovimientoPrestamoForm";
+import PagoRegularModal from "../../../components/admin/PagoRegularModal";
+import { useResumen, useCreateMovimiento } from "./usePrestamo";
+import { formatCOP2 } from "./prestamoUtils";
+import "../../../styles/admin/prestamo.css";
+
+const PrestamoDashboard = () => {
+  const { data: resumen, isLoading, isError } = useResumen();
+  const createMut = useCreateMovimiento();
+  const [showModal, setShowModal] = useState(false);
+  const [showPago, setShowPago] = useState(false);
+  const [submitError, setSubmitError] = useState(null);
+
+  const handleSubmit = async (payload) => {
+    setSubmitError(null);
+    try {
+      await createMut.mutateAsync(payload);
+      setShowModal(false);
+    } catch (err) {
+      const data = err.response?.data;
+      setSubmitError(
+        data?.message ||
+          (data && typeof data === "object"
+            ? Object.values(data).flat().join(" ")
+            : "No se pudo registrar el movimiento.")
+      );
+    }
+  };
+
+  if (isLoading) {
+    return <section className="pr-page"><p className="pr-muted">Cargando resumen…</p></section>;
+  }
+  if (isError || !resumen) {
+    return (
+      <section className="pr-page">
+        <p className="pr-error">No se pudo cargar el resumen del préstamo.</p>
+      </section>
+    );
+  }
+  if (resumen.configurado === false) {
+    return (
+      <section className="pr-page">
+        <TitleCrud title="Control de Préstamo" icon={Landmark} description="Seguimiento de la deuda" />
+        <p className="pr-muted">
+          Aún no hay configuración sembrada. Ejecuta{" "}
+          <code>python manage.py seed_prestamo</code> en el backend.
+        </p>
+      </section>
+    );
+  }
+
+  const { amigo, dueno, banco, mes_en_curso, plazo } = resumen;
+
+  return (
+    <section className="pr-page">
+      <TitleCrud
+        title="Control de Préstamo"
+        icon={Landmark}
+        description={`Mes en curso: ${mes_en_curso} de ${plazo} · corte día ${resumen.fecha_corte}`}
+      />
+
+      <div className="pr-toolbar">
+        <button className="pr-btn pr-btn--accent" onClick={() => setShowPago(true)}>
+          <CalendarCheck size={16} /> Realizar pago regular
+        </button>
+        <button className="pr-btn pr-btn--primary" onClick={() => setShowModal(true)}>
+          <Plus size={16} /> Registrar abono
+        </button>
+        <Link to="/admin/prestamo/movimientos" className="pr-btn">
+          <History size={16} /> Historial
+        </Link>
+        <Link to="/admin/prestamo/proyeccion" className="pr-btn">
+          <TableProperties size={16} /> Proyección
+        </Link>
+      </div>
+
+      {/* Saldos por tramo */}
+      <div className="pr-cards">
+        <article className="pr-card pr-card--amigo">
+          <div className="pr-card-head"><User size={20} /><span>Amigo</span></div>
+          <p className="pr-card-label">Saldo actual</p>
+          <h2 className="pr-card-value">{formatCOP2(amigo.saldo_actual)}</h2>
+          <div className="pr-card-foot">
+            <div><Receipt size={14} /> Próxima cuota <b>{formatCOP2(amigo.proxima_cuota)}</b></div>
+            <div><Percent size={14} /> Próximo 2% <b>{formatCOP2(amigo.proximo_2pct)}</b></div>
+          </div>
+        </article>
+
+        <article className="pr-card pr-card--dueno">
+          <div className="pr-card-head"><UserCog size={20} /><span>Dueño</span></div>
+          <p className="pr-card-label">Saldo actual</p>
+          <h2 className="pr-card-value">{formatCOP2(dueno.saldo_actual)}</h2>
+          <div className="pr-card-foot">
+            <div><Receipt size={14} /> Próxima cuota <b>{formatCOP2(dueno.proxima_cuota)}</b></div>
+          </div>
+        </article>
+
+        <article className="pr-card pr-card--banco">
+          <div className="pr-card-head"><Landmark size={20} /><span>Banco</span></div>
+          <p className="pr-card-label">Saldo total</p>
+          <h2 className="pr-card-value">{formatCOP2(banco.saldo_actual)}</h2>
+          <div className="pr-card-foot">
+            <div><CalendarClock size={14} /> Cuota total <b>{formatCOP2(banco.cuota_total)}</b></div>
+          </div>
+        </article>
+      </div>
+
+      {showModal && (
+        <MovimientoPrestamoForm
+          onClose={() => { setShowModal(false); setSubmitError(null); }}
+          onSubmit={handleSubmit}
+          isSubmitting={createMut.isPending}
+          submitError={submitError}
+        />
+      )}
+
+      {showPago && <PagoRegularModal onClose={() => setShowPago(false)} />}
+    </section>
+  );
+};
+
+export default PrestamoDashboard;

--- a/gaming-laptop-store/src/pages/admin/Prestamo/PrestamoMovimientos.jsx
+++ b/gaming-laptop-store/src/pages/admin/Prestamo/PrestamoMovimientos.jsx
@@ -1,0 +1,170 @@
+import React, { useMemo, useState } from "react";
+import { History, FileText, Plus, CalendarCheck } from "lucide-react";
+import { FaTrashAlt } from "react-icons/fa";
+
+import TitleCrud from "../../../components/admin/TitleCrud";
+import DataTable from "../../../components/admin/DataTable";
+import ConfirmModal from "../../../components/admin/ConfirmModal";
+import MovimientoPrestamoForm from "../../../components/admin/MovimientoPrestamoForm";
+import PagoRegularModal from "../../../components/admin/PagoRegularModal";
+import {
+  useMovimientos,
+  useCreateMovimiento,
+  useUpdateMovimiento,
+  useDeleteMovimiento,
+} from "./usePrestamo";
+import { formatCOP2, TIPO_LABELS, TIPO_OPTIONS } from "./prestamoUtils";
+import "../../../styles/admin/prestamo.css";
+
+const PrestamoMovimientos = () => {
+  const [filtroTipo, setFiltroTipo] = useState("");
+  const [filtroTramo, setFiltroTramo] = useState("");
+  const params = useMemo(() => {
+    const p = {};
+    if (filtroTipo) p.tipo = filtroTipo;
+    if (filtroTramo) p.tramo = filtroTramo;
+    return p;
+  }, [filtroTipo, filtroTramo]);
+
+  const { data: movimientos = [], isLoading } = useMovimientos(params);
+  const createMut = useCreateMovimiento();
+  const updateMut = useUpdateMovimiento();
+  const deleteMut = useDeleteMovimiento();
+
+  const [showModal, setShowModal] = useState(false);
+  const [showPago, setShowPago] = useState(false);
+  const [editing, setEditing] = useState(null);
+  const [submitError, setSubmitError] = useState(null);
+  const [confirmDialog, setConfirmDialog] = useState(null);
+
+  const openCreate = () => { setEditing(null); setSubmitError(null); setShowModal(true); };
+  const openEdit = (row) => { setEditing(row); setSubmitError(null); setShowModal(true); };
+  const closeModal = () => { setShowModal(false); setEditing(null); setSubmitError(null); };
+
+  const handleSubmit = async (payload, id) => {
+    setSubmitError(null);
+    try {
+      if (id) await updateMut.mutateAsync({ id, payload });
+      else await createMut.mutateAsync(payload);
+      closeModal();
+    } catch (err) {
+      const data = err.response?.data;
+      setSubmitError(
+        data?.message ||
+          (data && typeof data === "object"
+            ? Object.values(data).flat().join(" ")
+            : "No se pudo guardar el movimiento.")
+      );
+    }
+  };
+
+  const handleDelete = (row) => {
+    setConfirmDialog({
+      title: `¿Eliminar ${TIPO_LABELS[row.tipo] || row.tipo}?`,
+      message: `Se borrará el movimiento de ${formatCOP2(row.monto)} del ${row.fecha}. El motor recalculará la proyección.`,
+      confirmLabel: "Sí, eliminar",
+      isDestructive: true,
+      onConfirm: async () => {
+        try {
+          await deleteMut.mutateAsync(row.id);
+        } finally {
+          setConfirmDialog(null);
+        }
+      },
+    });
+  };
+
+  const columns = [
+    { key: "fecha", label: "Fecha" },
+    {
+      key: "tipo",
+      label: "Tipo",
+      render: (r) => (
+        <span className={`pr-badge pr-badge--${r.tramo}`}>
+          {TIPO_LABELS[r.tipo] || r.tipo}
+        </span>
+      ),
+    },
+    { key: "tramo", label: "Tramo", render: (r) => (r.tramo === "amigo" ? "Amigo" : "Dueño") },
+    { key: "monto", label: "Monto", render: (r) => formatCOP2(r.monto) },
+    { key: "nota", label: "Nota", render: (r) => r.nota || "—" },
+    {
+      key: "comprobante_url",
+      label: "Comprobante",
+      render: (r) =>
+        r.comprobante_url ? (
+          <a href={r.comprobante_url} target="_blank" rel="noreferrer" className="pr-link">
+            <FileText size={14} /> Ver
+          </a>
+        ) : (
+          "—"
+        ),
+    },
+    { key: "autor_email", label: "Autor", render: (r) => r.autor_email || "—" },
+  ];
+
+  return (
+    <section className="pr-page">
+      <TitleCrud title="Movimientos" icon={History} description="Historial de cuotas, abonos y comisiones" />
+
+      <div className="pr-toolbar">
+        <button className="pr-btn pr-btn--accent" onClick={() => setShowPago(true)}>
+          <CalendarCheck size={16} /> Realizar pago regular
+        </button>
+        <button className="pr-btn pr-btn--primary" onClick={openCreate}>
+          <Plus size={16} /> Registrar abono
+        </button>
+        <select className="pr-select" value={filtroTipo} onChange={(e) => setFiltroTipo(e.target.value)}>
+          <option value="">Todos los tipos</option>
+          {TIPO_OPTIONS.map((o) => (
+            <option key={o.value} value={o.value}>{o.label}</option>
+          ))}
+        </select>
+        <select className="pr-select" value={filtroTramo} onChange={(e) => setFiltroTramo(e.target.value)}>
+          <option value="">Ambos tramos</option>
+          <option value="amigo">Amigo</option>
+          <option value="dueno">Dueño</option>
+        </select>
+      </div>
+
+      {isLoading ? (
+        <p className="pr-muted">Cargando movimientos…</p>
+      ) : (
+        <DataTable
+          columns={columns}
+          data={movimientos}
+          rowKey="id"
+          onEdit={openEdit}
+          customActions={[
+            { icon: FaTrashAlt, handler: handleDelete, show: () => true, title: "Eliminar", destructive: true },
+          ]}
+        />
+      )}
+
+      {showModal && (
+        <MovimientoPrestamoForm
+          onClose={closeModal}
+          onSubmit={handleSubmit}
+          movimiento={editing}
+          isSubmitting={createMut.isPending || updateMut.isPending}
+          submitError={submitError}
+        />
+      )}
+
+      {showPago && <PagoRegularModal onClose={() => setShowPago(false)} />}
+
+      {confirmDialog && (
+        <ConfirmModal
+          title={confirmDialog.title}
+          message={confirmDialog.message}
+          confirmLabel={confirmDialog.confirmLabel}
+          isDestructive={confirmDialog.isDestructive}
+          onConfirm={confirmDialog.onConfirm}
+          onCancel={() => setConfirmDialog(null)}
+        />
+      )}
+    </section>
+  );
+};
+
+export default PrestamoMovimientos;

--- a/gaming-laptop-store/src/pages/admin/Prestamo/PrestamoProyeccion.jsx
+++ b/gaming-laptop-store/src/pages/admin/Prestamo/PrestamoProyeccion.jsx
@@ -1,0 +1,105 @@
+import React, { useMemo } from "react";
+import { TableProperties } from "lucide-react";
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+} from "recharts";
+
+import TitleCrud from "../../../components/admin/TitleCrud";
+import { useProyeccion, useResumen } from "./usePrestamo";
+import { formatCOP, formatCOP2 } from "./prestamoUtils";
+import "../../../styles/admin/prestamo.css";
+
+const PrestamoProyeccion = () => {
+  const { data: proyeccion = [], isLoading } = useProyeccion();
+  const { data: resumen } = useResumen();
+  const mesActual = resumen?.mes_en_curso;
+
+  const chartData = useMemo(
+    () =>
+      proyeccion.map((p) => ({
+        mes: p.mes,
+        Amigo: Number(p.amigo.saldo_final),
+        Dueño: Number(p.dueno.saldo_final),
+        Banco: Number(p.banco.saldo_final),
+      })),
+    [proyeccion]
+  );
+
+  return (
+    <section className="pr-page">
+      <TitleCrud
+        title="Proyección"
+        icon={TableProperties}
+        description="Tabla mes a mes hasta el final del plazo. Los abonos la modifican."
+      />
+
+      {isLoading ? (
+        <p className="pr-muted">Cargando proyección…</p>
+      ) : (
+        <>
+          <div className="pr-chart">
+            <ResponsiveContainer width="100%" height={320}>
+              <LineChart data={chartData} margin={{ top: 8, right: 16, bottom: 8, left: 8 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+                <XAxis dataKey="mes" tick={{ fontSize: 12 }} />
+                <YAxis
+                  tickFormatter={(v) => formatCOP(v)}
+                  width={90}
+                  tick={{ fontSize: 11 }}
+                />
+                <Tooltip formatter={(v) => formatCOP2(v)} labelFormatter={(l) => `Mes ${l}`} />
+                <Legend />
+                <Line type="monotone" dataKey="Banco" stroke="#0A6FA8" strokeWidth={2} dot={false} />
+                <Line type="monotone" dataKey="Amigo" stroke="#2979C8" strokeWidth={2} dot={false} />
+                <Line type="monotone" dataKey="Dueño" stroke="#7ED4F7" strokeWidth={2} dot={false} />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+
+          <div className="pr-table-wrap">
+            <table className="pr-table">
+              <thead>
+                <tr>
+                  <th rowSpan={2}>Mes</th>
+                  <th colSpan={3}>Amigo</th>
+                  <th colSpan={2}>Dueño</th>
+                  <th>Banco</th>
+                </tr>
+                <tr>
+                  <th>Saldo ini.</th>
+                  <th>Cuota</th>
+                  <th>2%</th>
+                  <th>Saldo ini.</th>
+                  <th>Cuota</th>
+                  <th>Saldo fin</th>
+                </tr>
+              </thead>
+              <tbody>
+                {proyeccion.map((p) => (
+                  <tr key={p.mes} className={p.mes === mesActual ? "pr-row--actual" : ""}>
+                    <td>{p.mes}</td>
+                    <td>{formatCOP2(p.amigo.saldo_inicial)}</td>
+                    <td>{formatCOP2(p.amigo.cuota)}</td>
+                    <td>{formatCOP2(p.amigo.comision)}</td>
+                    <td>{formatCOP2(p.dueno.saldo_inicial)}</td>
+                    <td>{formatCOP2(p.dueno.cuota)}</td>
+                    <td>{formatCOP2(p.banco.saldo_final)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </>
+      )}
+    </section>
+  );
+};
+
+export default PrestamoProyeccion;

--- a/gaming-laptop-store/src/pages/admin/Prestamo/prestamoUtils.js
+++ b/gaming-laptop-store/src/pages/admin/Prestamo/prestamoUtils.js
@@ -1,0 +1,47 @@
+// Utilidades compartidas de las pantallas de Préstamo.
+
+/** Formatea un número/string a pesos colombianos sin decimales. */
+export function formatCOP(value) {
+  const n = Number(value);
+  if (!Number.isFinite(n)) return "—";
+  return new Intl.NumberFormat("es-CO", {
+    style: "currency",
+    currency: "COP",
+    maximumFractionDigits: 0,
+  }).format(n);
+}
+
+/** Formatea con 2 decimales (para montos exactos del préstamo). */
+export function formatCOP2(value) {
+  const n = Number(value);
+  if (!Number.isFinite(n)) return "—";
+  return new Intl.NumberFormat("es-CO", {
+    style: "currency",
+    currency: "COP",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(n);
+}
+
+export const TIPO_LABELS = {
+  cuota_amigo: "Cuota amigo",
+  cuota_dueno: "Cuota dueño",
+  abono_amigo: "Abono amigo",
+  abono_dueno: "Abono dueño",
+  comision_2pct: "Comisión 2%",
+};
+
+export const TIPO_OPTIONS = [
+  { value: "abono_amigo", label: "Abono amigo" },
+  { value: "abono_dueno", label: "Abono dueño" },
+  { value: "cuota_amigo", label: "Cuota amigo" },
+  { value: "cuota_dueno", label: "Cuota dueño" },
+  { value: "comision_2pct", label: "Comisión 2%" },
+];
+
+/** Fecha de hoy en formato YYYY-MM-DD (zona local). */
+export function hoyISO() {
+  const d = new Date();
+  const off = d.getTimezoneOffset();
+  return new Date(d.getTime() - off * 60000).toISOString().slice(0, 10);
+}

--- a/gaming-laptop-store/src/pages/admin/Prestamo/usePrestamo.js
+++ b/gaming-laptop-store/src/pages/admin/Prestamo/usePrestamo.js
@@ -1,0 +1,82 @@
+// Hooks de react-query para el Control de Préstamo.
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  getResumen,
+  getProyeccion,
+  getMovimientos,
+  createMovimiento,
+  updateMovimiento,
+  deleteMovimiento,
+  getAuditoria,
+  getPagoRegularPreview,
+  registrarPagoRegular,
+} from "../../../services/PrestamoService";
+
+const KEYS = {
+  resumen: ["prestamo", "resumen"],
+  proyeccion: ["prestamo", "proyeccion"],
+  movimientos: ["prestamo", "movimientos"],
+  auditoria: ["prestamo", "auditoria"],
+};
+
+export function useResumen() {
+  return useQuery({ queryKey: KEYS.resumen, queryFn: getResumen });
+}
+
+export function useProyeccion() {
+  return useQuery({ queryKey: KEYS.proyeccion, queryFn: getProyeccion });
+}
+
+export function useMovimientos(params = {}) {
+  return useQuery({
+    queryKey: [...KEYS.movimientos, params],
+    queryFn: () => getMovimientos(params),
+  });
+}
+
+export function useAuditoria() {
+  return useQuery({ queryKey: KEYS.auditoria, queryFn: getAuditoria });
+}
+
+// Tras cualquier mutación el motor recalcula: invalidamos todo lo derivado.
+function useInvalidateAll() {
+  const qc = useQueryClient();
+  return () => {
+    qc.invalidateQueries({ queryKey: ["prestamo"] });
+  };
+}
+
+export function useCreateMovimiento() {
+  const invalidate = useInvalidateAll();
+  return useMutation({ mutationFn: createMovimiento, onSuccess: invalidate });
+}
+
+export function useUpdateMovimiento() {
+  const invalidate = useInvalidateAll();
+  return useMutation({
+    mutationFn: ({ id, payload }) => updateMovimiento(id, payload),
+    onSuccess: invalidate,
+  });
+}
+
+export function useDeleteMovimiento() {
+  const invalidate = useInvalidateAll();
+  return useMutation({ mutationFn: deleteMovimiento, onSuccess: invalidate });
+}
+
+export function usePagoRegularPreview(enabled = true) {
+  return useQuery({
+    queryKey: ["prestamo", "pago-regular-preview"],
+    queryFn: () => getPagoRegularPreview(),
+    enabled,
+    staleTime: 0,
+  });
+}
+
+export function useRegistrarPagoRegular() {
+  const invalidate = useInvalidateAll();
+  return useMutation({
+    mutationFn: (args) => registrarPagoRegular(args),
+    onSuccess: invalidate,
+  });
+}

--- a/gaming-laptop-store/src/services/PrestamoService.jsx
+++ b/gaming-laptop-store/src/services/PrestamoService.jsx
@@ -1,0 +1,89 @@
+import api from "./Api";
+import urls from "./Urls";
+
+/**
+ * Servicio del Control de Préstamo. Mapea la API /api/prestamo/.
+ * Las respuestas del backend vienen envueltas ({ resumen }, { proyeccion },
+ * { movimientos }, etc.); aquí se desenvuelven para el frontend.
+ */
+
+// ---- Resumen / proyección -------------------------------------------------
+
+export async function getResumen() {
+  const { data } = await api.get(urls.prestamoResumen);
+  return data.resumen ?? data;
+}
+
+export async function getProyeccion() {
+  const { data } = await api.get(urls.prestamoProyeccion);
+  return data.proyeccion ?? data;
+}
+
+// ---- Movimientos ----------------------------------------------------------
+
+export async function getMovimientos(params = {}) {
+  const { data } = await api.get(urls.prestamoMovimientos, { params });
+  return data.movimientos ?? data;
+}
+
+export async function createMovimiento(payload) {
+  const { data } = await api.post(urls.prestamoMovimientos, payload);
+  return data.movimiento ?? data;
+}
+
+export async function updateMovimiento(id, payload) {
+  const { data } = await api.patch(urls.prestamoMovimientoDetail(id), payload);
+  return data.movimiento ?? data;
+}
+
+export async function deleteMovimiento(id) {
+  const { data } = await api.delete(urls.prestamoMovimientoDetail(id));
+  return data;
+}
+
+// ---- Pago regular (las 3 líneas del corte del día 11) ---------------------
+
+export async function getPagoRegularPreview(mes) {
+  const { data } = await api.get(urls.prestamoPagoRegular, {
+    params: mes ? { mes } : {},
+  });
+  return data.pago_regular ?? data;
+}
+
+export async function registrarPagoRegular({ mes, comprobanteUrl } = {}) {
+  const payload = {};
+  if (mes) payload.mes = mes;
+  if (comprobanteUrl) payload.comprobante_url = comprobanteUrl;
+  const { data } = await api.post(urls.prestamoPagoRegular, payload);
+  return data;
+}
+
+// ---- Comprobantes ---------------------------------------------------------
+
+export async function uploadComprobante(file) {
+  const form = new FormData();
+  form.append("archivo", file);
+  const { data } = await api.post(urls.prestamoComprobantes, form, {
+    headers: { "Content-Type": "multipart/form-data" },
+  });
+  return data.comprobante_url;
+}
+
+// ---- Auditoría ------------------------------------------------------------
+
+export async function getAuditoria() {
+  const { data } = await api.get(urls.prestamoAuditoria);
+  return data.auditoria ?? data;
+}
+
+// ---- Configuración --------------------------------------------------------
+
+export async function getConfiguracion() {
+  const { data } = await api.get(urls.prestamoConfiguracion);
+  return data.configuracion ?? data;
+}
+
+export async function updateConfiguracion(payload) {
+  const { data } = await api.put(urls.prestamoConfiguracion, payload);
+  return data.configuracion ?? data;
+}

--- a/gaming-laptop-store/src/services/Urls.jsx
+++ b/gaming-laptop-store/src/services/Urls.jsx
@@ -188,6 +188,16 @@ const urls = {
 
   dwTelegramSubscribersList: `${BASE_URL}/deal-watcher/telegram-subscribers/list/`,
   dwTelegramSubscribersDeactivate: (id) => `${BASE_URL}/deal-watcher/telegram-subscribers/deactivate/${id}/`,
+
+  // PRÉSTAMO — control de préstamo (app aislada, prefijo /api/prestamo/)
+  prestamoResumen: `${BASE_URL}/api/prestamo/resumen/`,
+  prestamoProyeccion: `${BASE_URL}/api/prestamo/proyeccion/`,
+  prestamoMovimientos: `${BASE_URL}/api/prestamo/movimientos/`,
+  prestamoMovimientoDetail: (id) => `${BASE_URL}/api/prestamo/movimientos/${id}/`,
+  prestamoPagoRegular: `${BASE_URL}/api/prestamo/pago-regular/`,
+  prestamoComprobantes: `${BASE_URL}/api/prestamo/comprobantes/`,
+  prestamoAuditoria: `${BASE_URL}/api/prestamo/auditoria/`,
+  prestamoConfiguracion: `${BASE_URL}/api/prestamo/configuracion/`,
 };
 
 export default urls;

--- a/gaming-laptop-store/src/styles/admin/prestamo.css
+++ b/gaming-laptop-store/src/styles/admin/prestamo.css
@@ -1,0 +1,244 @@
+/* Estilos de la sección Préstamo (prefijo .pr-). */
+
+.pr-page {
+  padding: 1.25rem 1.5rem 2.5rem;
+}
+
+.pr-muted { color: #6b7280; }
+.pr-error { color: #dc2626; font-weight: 600; margin-top: 0.75rem; }
+.pr-hint { color: #6b7280; font-size: 0.8rem; }
+
+/* Toolbar -------------------------------------------------------------- */
+.pr-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+  margin: 1rem 0 1.25rem;
+}
+
+.pr-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.5rem 0.9rem;
+  border-radius: 0.55rem;
+  border: 1px solid #d1d5db;
+  background: #fff;
+  color: #1f2937;
+  font-size: 0.88rem;
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: none;
+  transition: background 0.15s, border-color 0.15s;
+}
+.pr-btn:hover { background: #f3f4f6; }
+.pr-btn--primary {
+  background: #2979c8;
+  border-color: #2979c8;
+  color: #fff;
+}
+.pr-btn--primary:hover { background: #0a6fa8; }
+.pr-btn--accent {
+  background: #15803d;
+  border-color: #15803d;
+  color: #fff;
+}
+.pr-btn--accent:hover { background: #126b34; }
+
+/* Pago regular (modal) ------------------------------------------------- */
+.pr-pago-list {
+  list-style: none;
+  margin: 0.25rem 0 0.75rem;
+  padding: 0;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.6rem;
+  overflow: hidden;
+}
+.pr-pago-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.65rem 0.9rem;
+  border-bottom: 1px solid #f1f5f9;
+}
+.pr-pago-row:last-child { border-bottom: none; }
+.pr-pago-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  color: #374151;
+  font-size: 0.9rem;
+}
+.pr-pago-val { font-weight: 700; color: #111827; white-space: nowrap; }
+.pr-pago-row--total {
+  background: #f9fafb;
+  border-top: 2px solid #e5e7eb;
+}
+.pr-pago-row--total .pr-pago-label { font-weight: 800; color: #111827; }
+.pr-pago-row--total .pr-pago-val { color: #15803d; font-size: 1.05rem; }
+
+.pr-notice {
+  border-radius: 0.55rem;
+  padding: 0.6rem 0.8rem;
+  font-size: 0.86rem;
+  margin-bottom: 0.75rem;
+}
+.pr-notice--warn { background: #fef9c3; color: #854d0e; }
+
+.pr-select {
+  padding: 0.5rem 0.7rem;
+  border-radius: 0.55rem;
+  border: 1px solid #d1d5db;
+  background: #fff;
+  font-size: 0.88rem;
+  color: #1f2937;
+}
+
+/* Cards de saldos ------------------------------------------------------ */
+.pr-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1rem;
+}
+
+.pr-card {
+  border-radius: 0.9rem;
+  padding: 1.1rem 1.25rem;
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+  border-top: 4px solid #2979c8;
+}
+.pr-card--amigo { border-top-color: #2979c8; }
+.pr-card--dueno { border-top-color: #7ed4f7; }
+.pr-card--banco { border-top-color: #0a6fa8; }
+
+.pr-card-head {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 700;
+  color: #374151;
+  margin-bottom: 0.5rem;
+}
+.pr-card-label { color: #6b7280; font-size: 0.8rem; margin: 0; }
+.pr-card-value {
+  margin: 0.2rem 0 0.8rem;
+  font-size: 1.7rem;
+  font-weight: 800;
+  color: #111827;
+  letter-spacing: -0.5px;
+}
+.pr-card-foot {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  border-top: 1px dashed #e5e7eb;
+  padding-top: 0.6rem;
+}
+.pr-card-foot > div {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.82rem;
+  color: #6b7280;
+}
+.pr-card-foot b { color: #1f2937; margin-left: auto; }
+
+/* Tabla de proyección -------------------------------------------------- */
+.pr-chart {
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.9rem;
+  padding: 1rem 0.5rem 0.5rem;
+  margin-bottom: 1.25rem;
+}
+
+.pr-table-wrap {
+  overflow-x: auto;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.9rem;
+  background: #fff;
+}
+.pr-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.82rem;
+}
+.pr-table th,
+.pr-table td {
+  padding: 0.5rem 0.7rem;
+  text-align: right;
+  white-space: nowrap;
+}
+.pr-table thead th {
+  background: #f9fafb;
+  color: #374151;
+  font-weight: 700;
+  border-bottom: 1px solid #e5e7eb;
+  text-align: center;
+}
+.pr-table tbody td:first-child,
+.pr-table thead th:first-child { text-align: center; }
+.pr-table tbody tr:nth-child(even) { background: #fcfcfd; }
+.pr-row--actual {
+  background: #eaf6ff !important;
+  font-weight: 700;
+}
+
+/* Badges --------------------------------------------------------------- */
+.pr-badge {
+  display: inline-block;
+  padding: 0.15rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.74rem;
+  font-weight: 700;
+}
+.pr-badge--amigo { background: #e0edfb; color: #1d4ed8; }
+.pr-badge--dueno { background: #e6f7fe; color: #0a6fa8; }
+.pr-badge--crear { background: #dcfce7; color: #15803d; }
+.pr-badge--editar { background: #fef9c3; color: #a16207; }
+.pr-badge--borrar { background: #fee2e2; color: #b91c1c; }
+
+.pr-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  color: #2979c8;
+  text-decoration: none;
+  font-weight: 600;
+}
+.pr-link:hover { text-decoration: underline; }
+
+/* Formulario modal ----------------------------------------------------- */
+.pr-form-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.9rem;
+}
+.pr-field { display: flex; flex-direction: column; gap: 0.3rem; }
+.pr-field--full { grid-column: 1 / -1; }
+.pr-field > span { font-size: 0.82rem; font-weight: 600; color: #374151; }
+.pr-field input,
+.pr-field select,
+.pr-field textarea {
+  padding: 0.5rem 0.65rem;
+  border: 1px solid #d1d5db;
+  border-radius: 0.5rem;
+  font-size: 0.9rem;
+  font-family: inherit;
+}
+.pr-field input:focus,
+.pr-field select:focus,
+.pr-field textarea:focus {
+  outline: none;
+  border-color: #2979c8;
+  box-shadow: 0 0 0 2px rgba(41, 121, 200, 0.15);
+}
+
+@media (max-width: 640px) {
+  .pr-form-grid { grid-template-columns: 1fr; }
+  .pr-page { padding: 1rem; }
+}


### PR DESCRIPTION
Nueva sección "Préstamo" como primera del sidebar (/admin redirige ahí):
- Páginas: Resumen (saldos amigo/dueño/banco + acciones), Movimientos (historial CRUD), Proyección (Recharts + tabla 48 meses), Auditoría.
- Botón "Realizar pago regular": registra de una vez las 3 líneas del corte del día 11 (cuota amigo, cuota dueño y 2%) con comprobante opcional.
- Registro eventual limitado a abonos; servicio + hooks react-query.